### PR TITLE
Refine editor interface and clean feed content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ asynchronously. Use the controls at the top to choose the number of stories
 button pulls a fresh snapshot, and **Load More** dynamically appends additional
 stories without reloading the page. Each story is de‑duplicated, summarised via
 an open‑source NLP model, scored for relevance/bias/trendiness, and includes
-clickable references and perspective notes.
+clickable references, perspective notes, and basic numeric data points pulled
+from the article text. In addition to Google News, a secondary crawler pulls
+"curious" items from Smithsonian, Britannica, History.com, Science.org, Nature
+and Encyclopedia.com to surface lesser‑known technology, medical and history
+stories.
 
 ### Twitter trends
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Open `http://localhost:5000` and the dashboard will load the latest 20 stories
 asynchronously. Use the controls at the top to choose the number of stories
 (20–100) and sorting method (latest, trending, top, or oldest). The **Refresh**
 button pulls a fresh snapshot, and **Load More** dynamically appends additional
-stories without reloading the page.
+stories without reloading the page. Each story is de‑duplicated, summarised via
+an open‑source NLP model, scored for relevance/bias/trendiness, and includes
+clickable references and perspective notes.
 
 ### Twitter trends
 

--- a/README.md
+++ b/README.md
@@ -16,24 +16,27 @@ Run the web interface:
 PYTHONPATH=. python newsfeed/app.py
 ```
 
-Access `http://localhost:5000/?limit=20` to view the top 20 stories. The list is
-paginated; adjust the `page` query parameter or use the form on the page to
-navigate. The limit can be any value between 1 and 100. Stories can also be
-sorted via the `sort` query parameter with options `latest`, `trending`, `top`,
-or `oldest`.
+Open `http://localhost:5000` and the dashboard will load the latest 20 stories
+asynchronously. Use the controls at the top to choose the number of stories
+(20–100) and sorting method (latest, trending, top, or oldest). The **Refresh**
+button pulls a fresh snapshot, and **Load More** dynamically appends additional
+stories without reloading the page.
 
 ### Twitter trends
 
-High-impact tweets can be included in the feed. Provide a Twitter API bearer
-token via the `TWITTER_BEARER_TOKEN` environment variable:
+Trending topics from Twitter can be blended into the feed. Provide Twitter API
+credentials via environment variables. The agent will exchange the key and
+secret for a bearer token when needed.
 
 ```bash
-export TWITTER_BEARER_TOKEN=YOUR_TOKEN
+export TWITTER_API_KEY=pSE413xxsPnvqoHpBdKBiQwFd
+export TWITTER_API_SECRET=qJKaTw6jGPHdRnxoYfRwGmL8VrTlw5Q4qFPA4jJagyebIgmOTP
+# optional pre-generated token
+# export TWITTER_BEARER_TOKEN=YOUR_TOKEN
 ```
 
-The `TwitterTrendsFetcher` class in `newsfeed/twitter_feed.py` queries a few
-predefined influential accounts and converts their latest tweets into
-`Story` objects.
+`TwitterTrendsFetcher` in `newsfeed/twitter_feed.py` crawls the trending, news,
+and entertainment tabs and converts the top topics into `Story` objects.
 
 ## Deployment on Vercel
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ PYTHONPATH=. python newsfeed/app.py
 
 Access `http://localhost:5000/?limit=20` to view the top 20 stories. The list is
 paginated; adjust the `page` query parameter or use the form on the page to
-navigate. The limit can be any value between 1 and 100.
+navigate. The limit can be any value between 1 and 100. Stories can also be
+sorted via the `sort` query parameter with options `latest`, `trending`, `top`,
+or `oldest`.
 
 ### Twitter trends
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
 # NewsFeedAgent
+
+Prototype implementation of an AI-powered news feed analyzer.
+
+## Usage
+
+Install dependencies:
+
+```bash
+python -m pip install -r requirements.txt  # or feedparser and Flask
+```
+
+Run the web interface:
+
+```bash
+PYTHONPATH=. python newsfeed/app.py
+```
+
+Access `http://localhost:5000/?limit=20` to view the top 20 stories. The limit can be any value between 1 and 100.
+
+## Deployment on Vercel
+
+The repository includes a minimal `vercel.json` and an `api/index.py` entrypoint
+so the Flask app can run as a serverless function on [Vercel](https://vercel.com).
+
+1. Push this repository to GitHub.
+2. In the Vercel dashboard choose **New Project** → **Import Git Repository** and
+   select your fork.
+3. Keep the default settings; Vercel will install the dependencies from
+   `requirements.txt` and build the Python function defined in `api/index.py`.
+4. After the deployment finishes, Vercel provides a URL such as
+   `https://your-project-name.vercel.app` where the news feed is available.
+
+## Generating Briefs via CLI
+
+`generate_brief.py` prints a markdown summary of the top stories and can be
+scheduled via cron to run before the 13:00 IST delivery time:
+
+```bash
+PYTHONPATH=. python generate_brief.py --limit 20 > brief.md
+```
+
+The generated `brief.md` can then be emailed or posted to Slack.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,22 @@ Run the web interface:
 PYTHONPATH=. python newsfeed/app.py
 ```
 
-Access `http://localhost:5000/?limit=20` to view the top 20 stories. The limit can be any value between 1 and 100.
+Access `http://localhost:5000/?limit=20` to view the top 20 stories. The list is
+paginated; adjust the `page` query parameter or use the form on the page to
+navigate. The limit can be any value between 1 and 100.
+
+### Twitter trends
+
+High-impact tweets can be included in the feed. Provide a Twitter API bearer
+token via the `TWITTER_BEARER_TOKEN` environment variable:
+
+```bash
+export TWITTER_BEARER_TOKEN=YOUR_TOKEN
+```
+
+The `TwitterTrendsFetcher` class in `newsfeed/twitter_feed.py` queries a few
+predefined influential accounts and converts their latest tweets into
+`Story` objects.
 
 ## Deployment on Vercel
 

--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,6 @@
+"""Vercel entrypoint exposing the Flask app as a serverless function."""
+
+from newsfeed.app import app
+
+__all__ = ["app"]
+

--- a/generate_brief.py
+++ b/generate_brief.py
@@ -24,6 +24,9 @@ def main() -> None:
             heading += f" ({story.source})"
         print(f"# {heading}\n")
         print(story.summary)
+        print("\nPerspectives:")
+        for p in story.perspectives:
+            print(f"- {p.label}: {p.text}")
         print("\nReferences:")
         for ref in story.references:
             print(f"- {ref.title} - {ref.link}")

--- a/generate_brief.py
+++ b/generate_brief.py
@@ -1,0 +1,35 @@
+"""Command-line helper to generate a text brief of top stories.
+
+This can be scheduled via cron or any task scheduler. It prints a simple
+markdown summary to stdout which can be redirected to a file or sent via
+email/Slack.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from newsfeed.fetcher import fetch_top_stories
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a daily news brief")
+    parser.add_argument("--limit", type=int, default=10, help="Number of stories")
+    args = parser.parse_args()
+
+    stories = fetch_top_stories(limit=args.limit)
+    for story in stories:
+        heading = story.title
+        if getattr(story, "source", ""):
+            heading += f" ({story.source})"
+        print(f"# {heading}\n")
+        print(story.summary)
+        print("\nReferences:")
+        for ref in story.references:
+            print(f"- {ref.title} - {ref.link}")
+        print("\n")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/newsfeed/__init__.py
+++ b/newsfeed/__init__.py
@@ -1,0 +1,1 @@
+"""News Feed Agent package."""

--- a/newsfeed/analytics.py
+++ b/newsfeed/analytics.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Lightweight NLP and scoring helpers."""
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Tuple
+
+from .models import Article, Score
+
+
+class Categorizer:
+    """Rough categorisation based on keywords."""
+
+    POLITICS = ["election", "minister", "parliament", "government", "policy"]
+    TECH = ["tech", "science", "ai", "technology", "health", "medical"]
+
+    def categorize(self, title: str, summary: str) -> str:
+        text = f"{title} {summary}".lower()
+        if any(k in text for k in self.POLITICS):
+            return "Politics"
+        if any(k in text for k in self.TECH):
+            return "Tech/Visual"
+        return "General"
+
+
+def categorize(title: str, summary: str) -> str:
+    return Categorizer().categorize(title, summary)
+
+
+class RelevanceScorer:
+    def score(self, article: Article) -> Score:
+        val = 1.0 if "india" in article.title.lower() else 0.5
+        expl = "Higher score for India-related titles" if val > 0.5 else "Generic relevance"
+        return Score(val, expl)
+
+
+class BiasScorer:
+    def score(self, article: Article) -> Score:
+        # Placeholder implementation
+        return Score(0.5, "Bias detection not yet implemented")
+
+
+class TrendPredictor:
+    def score(self, article: Article) -> Score:
+        hours_old = (datetime.now(timezone.utc) - article.published).total_seconds() / 3600
+        val = max(0.0, 1 - hours_old / 24)
+        expl = "Newer articles trend higher"
+        return Score(val, expl)
+
+
+class Analyzer:
+    """Combine categorisation and scoring into a single step."""
+
+    def __init__(self) -> None:
+        self.categorizer = Categorizer()
+        self.relevance = RelevanceScorer()
+        self.bias = BiasScorer()
+        self.trend = TrendPredictor()
+
+    def analyze(self, article: Article) -> Tuple[str, Score, Score, Score]:
+        category = self.categorizer.categorize(article.title, article.summary)
+        relevance = self.relevance.score(article)
+        bias = self.bias.score(article)
+        trending = self.trend.score(article)
+        return category, relevance, bias, trending

--- a/newsfeed/app.py
+++ b/newsfeed/app.py
@@ -30,6 +30,7 @@ def _story_to_dict(story: Story) -> dict:
         "perspectives": [
             {"label": p.label, "text": p.text} for p in story.perspectives
         ],
+        "stats": story.stats,
     }
 
 

--- a/newsfeed/app.py
+++ b/newsfeed/app.py
@@ -12,8 +12,20 @@ app = Flask(__name__)
 @app.route("/")
 def index():
     limit = request.args.get("limit", default=10, type=int)
-    stories = fetch_top_stories(limit)
-    return render_template("index.html", stories=stories)
+    page = request.args.get("page", default=1, type=int)
+    all_stories = fetch_top_stories(limit * page)
+    start = (page - 1) * limit
+    stories = all_stories[start : start + limit]
+    next_page = page + 1 if len(all_stories) > page * limit else None
+    prev_page = page - 1 if page > 1 else None
+    return render_template(
+        "index.html",
+        stories=stories,
+        limit=limit,
+        page=page,
+        next_page=next_page,
+        prev_page=prev_page,
+    )
 
 
 if __name__ == "__main__":

--- a/newsfeed/app.py
+++ b/newsfeed/app.py
@@ -13,7 +13,8 @@ app = Flask(__name__)
 def index():
     limit = request.args.get("limit", default=10, type=int)
     page = request.args.get("page", default=1, type=int)
-    all_stories = fetch_top_stories(limit * page)
+    sort = request.args.get("sort", default="latest", type=str)
+    all_stories = fetch_top_stories(limit * page, sort=sort)
     start = (page - 1) * limit
     stories = all_stories[start : start + limit]
     next_page = page + 1 if len(all_stories) > page * limit else None
@@ -23,6 +24,7 @@ def index():
         stories=stories,
         limit=limit,
         page=page,
+        sort=sort,
         next_page=next_page,
         prev_page=prev_page,
     )

--- a/newsfeed/app.py
+++ b/newsfeed/app.py
@@ -27,6 +27,9 @@ def _story_to_dict(story: Story) -> dict:
         "references": [
             {"title": ref.title, "link": ref.link} for ref in story.references
         ],
+        "perspectives": [
+            {"label": p.label, "text": p.text} for p in story.perspectives
+        ],
     }
 
 

--- a/newsfeed/app.py
+++ b/newsfeed/app.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+"""Flask interface presenting analyzed news stories."""
+
+from flask import Flask, render_template, request
+
+from .fetcher import fetch_top_stories
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def index():
+    limit = request.args.get("limit", default=10, type=int)
+    stories = fetch_top_stories(limit)
+    return render_template("index.html", stories=stories)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/newsfeed/crawler.py
+++ b/newsfeed/crawler.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+"""Crawler modules responsible for gathering raw articles."""
+
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from html import unescape
+from typing import List
+from urllib.parse import quote_plus
+import re
+import requests
+import feedparser
+
+from .models import Article, Reference
+
+LI_RE = re.compile(r"<li>(.*?)</li>", re.DOTALL)
+
+
+def _clean_summary(html_snippet: str) -> str:
+    match = LI_RE.search(html_snippet or "")
+    snippet = match.group(1) if match else html_snippet
+    text = re.sub(r"<[^>]+>", "", snippet)
+    return unescape(text).strip()
+
+
+def _split_title_source(title: str) -> tuple[str, str]:
+    if " - " in title:
+        return title.rsplit(" - ", 1)
+    return title, ""
+
+
+def _resolve_link(link: str) -> str:
+    if "news.google.com" not in link:
+        return link
+    try:
+        resp = requests.get(link, timeout=5, allow_redirects=True)
+        return resp.url
+    except Exception:
+        return link
+
+
+def related_links(title: str) -> List[Reference]:
+    """Fetch up to four related links for the given story title."""
+    search_url = (
+        "https://news.google.com/rss/search?q="
+        f"{quote_plus(title)}&hl=en-IN&gl=IN&ceid=IN:en"
+    )
+    data = feedparser.parse(search_url)
+    refs: List[Reference] = []
+    for e in data.entries[:4]:
+        r_title, _ = _split_title_source(e.get("title", ""))
+        r_link = _resolve_link(e.get("link", ""))
+        refs.append(Reference(r_title, r_link))
+    while len(refs) < 4:
+        refs.append(Reference(title, ""))
+    return refs
+
+
+class BaseCrawler(ABC):
+    """Abstract crawler interface."""
+
+    @abstractmethod
+    def fetch(self, limit: int) -> List[Article]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class GoogleNewsCrawler(BaseCrawler):
+    """Crawler pulling articles from Google News RSS feed."""
+
+    FEED_URL = "https://news.google.com/rss?hl=en-IN&gl=IN&ceid=IN:en"
+
+    def fetch(self, limit: int) -> List[Article]:
+        data = feedparser.parse(self.FEED_URL)
+        entries = data.entries[:limit]
+        articles: List[Article] = []
+        seen_titles = set()
+        for entry in entries:
+            raw_title = entry.get("title", "")
+            title, source = _split_title_source(raw_title)
+            if title in seen_titles:
+                continue
+            seen_titles.add(title)
+            link = _resolve_link(entry.get("link", ""))
+            summary = _clean_summary(entry.get("summary", ""))
+            published = entry.get("published_parsed")
+            if published:
+                published_dt = datetime(*published[:6], tzinfo=timezone.utc)
+            else:
+                published_dt = datetime.now(timezone.utc)
+            articles.append(
+                Article(
+                    title=title,
+                    summary=summary,
+                    link=link,
+                    source=source,
+                    published=published_dt,
+                )
+            )
+        return articles

--- a/newsfeed/fetcher.py
+++ b/newsfeed/fetcher.py
@@ -1,181 +1,22 @@
 from __future__ import annotations
 
-"""Fetching and assembling news stories with basic scoring."""
+"""Public API for fetching analysed stories."""
 
-from dataclasses import dataclass
-from datetime import datetime, timezone
 from typing import List
 
-from urllib.parse import quote_plus
-import feedparser
-import re
-from html import unescape
-import requests
+from .story_builder import StoryBuilder
+from .models import Story
 
-LI_RE = re.compile(r"<li>(.*?)</li>", re.DOTALL)
+_builder = StoryBuilder()
 
 
-def _clean_summary(html_snippet: str) -> str:
-    """Extract plain text from a Google News summary block."""
-
-    match = LI_RE.search(html_snippet or "")
-    snippet = match.group(1) if match else html_snippet
-    text = re.sub(r"<[^>]+>", "", snippet)
-    return unescape(text).strip()
-
-
-def _split_title_source(title: str) -> tuple[str, str]:
-    """Split combined title into title and source."""
-
-    if " - " in title:
-        return title.rsplit(" - ", 1)
-    return title, ""
-
-
-def _resolve_link(link: str) -> str:
-    """Follow Google News redirect to get the original article URL."""
-
-    if "news.google.com" not in link:
-        return link
-    try:
-        resp = requests.get(link, timeout=5, allow_redirects=True)
-        return resp.url
-    except Exception:
-        return link
-
-
-def _categorize(title: str, summary: str) -> str:
-    """Roughly classify a story into broad categories.
-
-    This is a heuristic placeholder until more advanced NLP models are added.
-    """
-
-    text = f"{title} {summary}".lower()
-    politics_kw = ["election", "minister", "parliament", "government", "policy"]
-    tech_kw = ["tech", "science", "ai", "technology", "health", "medical"]
-
-    if any(k in text for k in politics_kw):
-        return "Politics"
-    if any(k in text for k in tech_kw):
-        return "Tech/Visual"
-    return "General"
-
-
-@dataclass
-class Reference:
-    title: str
-    link: str
-
-
-@dataclass
-class Perspective:
-    viewpoint: str
-    detail: str
-
-
-@dataclass
-class Story:
-    """Structured representation of a news story."""
-
-    title: str
-    summary: str
-    link: str
-    source: str
-    category: str
-    relevance_score: float
-    bias_score: float
-    trending_score: float
-    perspectives: List[Perspective]
-    references: List[Reference]
-
-
-def _related_links(title: str) -> List[Reference]:
-    """Fetch up to four related links for the given story title."""
-
-    search_url = (
-        "https://news.google.com/rss/search?q="
-        f"{quote_plus(title)}&hl=en-IN&gl=IN&ceid=IN:en"
-    )
-    data = feedparser.parse(search_url)
-    refs: List[Reference] = []
-    for e in data.entries[:4]:
-        r_title, _ = _split_title_source(e.get("title", ""))
-        r_link = _resolve_link(e.get("link", ""))
-        refs.append(Reference(r_title, r_link))
-    while len(refs) < 4:
-        refs.append(Reference(title, ""))
-    return refs
-
-
-def fetch_top_stories(limit: int = 10, include_twitter: bool = True) -> List[Story]:
-    """Fetch top stories from Google News RSS feed and Twitter trends.
+def fetch_top_stories(limit: int = 10, sort: str = "latest", include_twitter: bool = True) -> List[Story]:
+    """Fetch analysed stories ready for presentation.
 
     Args:
         limit: Number of stories to return (1-100).
-
-    Returns:
-        List of Story objects limited by ``limit``.
+        sort: Ordering of stories - ``latest``, ``trending``, ``top`` or ``oldest``.
+        include_twitter: Whether to blend in Twitter trending stories.
     """
 
-    feed_url = "https://news.google.com/rss?hl=en-IN&gl=IN&ceid=IN:en"
-    data = feedparser.parse(feed_url)
-    limit = max(1, min(limit, 100))
-    google_limit = limit if not include_twitter else max(1, limit // 2)
-    entries = data.entries[:google_limit]
-    stories: List[Story] = []
-    seen_titles = set()
-
-    for entry in entries:
-        raw_title = entry.get("title", "")
-        title, source = _split_title_source(raw_title)
-        if title in seen_titles:
-            continue
-        seen_titles.add(title)
-        link = _resolve_link(entry.get("link", ""))
-        summary = _clean_summary(entry.get("summary", ""))
-        published = entry.get("published_parsed")
-
-        if published:
-            published_dt = datetime(*published[:6], tzinfo=timezone.utc)
-            hours_old = (datetime.now(timezone.utc) - published_dt).total_seconds() / 3600
-            trending_score = max(0.0, 1 - hours_old / 24)
-        else:
-            trending_score = 0.5
-
-        relevance_score = 1.0 if "India" in title else 0.5
-        bias_score = 0.5  # Placeholder until real bias detection is implemented
-        category = _categorize(title, summary)
-
-        perspectives = [
-            Perspective("left", f"Left perspective on {title}"),
-            Perspective("center", f"Centrist view on {title}"),
-            Perspective("right", f"Right perspective on {title}"),
-        ]
-
-        references = _related_links(title)
-
-        stories.append(
-            Story(
-                title=title,
-                summary=summary,
-                link=link,
-                source=source,
-                category=category,
-                relevance_score=relevance_score,
-                bias_score=bias_score,
-                trending_score=trending_score,
-                perspectives=perspectives,
-                references=references,
-            )
-        )
-
-    if include_twitter:
-        try:
-            from .twitter_feed import TwitterTrendsFetcher
-
-            t_fetcher = TwitterTrendsFetcher()
-            stories.extend(t_fetcher.fetch(limit - len(stories)))
-        except Exception:
-            pass
-
-    return stories
+    return _builder.build(limit=limit, sort=sort, include_twitter=include_twitter)

--- a/newsfeed/fetcher.py
+++ b/newsfeed/fetcher.py
@@ -10,7 +10,7 @@ from .models import Story
 _builder = StoryBuilder()
 
 
-def fetch_top_stories(limit: int = 10, sort: str = "latest", include_twitter: bool = True) -> List[Story]:
+def fetch_top_stories(limit: int = 20, sort: str = "latest", include_twitter: bool = True) -> List[Story]:
     """Fetch analysed stories ready for presentation.
 
     Args:

--- a/newsfeed/fetcher.py
+++ b/newsfeed/fetcher.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+"""Fetching and assembling news stories with basic scoring."""
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import List
+
+import feedparser
+import re
+from html import unescape
+import requests
+
+LI_RE = re.compile(r"<li>(.*?)</li>", re.DOTALL)
+
+
+def _clean_summary(html_snippet: str) -> str:
+    """Extract plain text from a Google News summary block."""
+
+    match = LI_RE.search(html_snippet or "")
+    snippet = match.group(1) if match else html_snippet
+    text = re.sub(r"<[^>]+>", "", snippet)
+    return unescape(text).strip()
+
+
+def _split_title_source(title: str) -> tuple[str, str]:
+    """Split combined title into title and source."""
+
+    if " - " in title:
+        return title.rsplit(" - ", 1)
+    return title, ""
+
+
+def _resolve_link(link: str) -> str:
+    """Follow Google News redirect to get the original article URL."""
+
+    if "news.google.com" not in link:
+        return link
+    try:
+        resp = requests.get(link, timeout=5, allow_redirects=True)
+        return resp.url
+    except Exception:
+        return link
+
+
+def _categorize(title: str, summary: str) -> str:
+    """Roughly classify a story into broad categories.
+
+    This is a heuristic placeholder until more advanced NLP models are added.
+    """
+
+    text = f"{title} {summary}".lower()
+    politics_kw = ["election", "minister", "parliament", "government", "policy"]
+    tech_kw = ["tech", "science", "ai", "technology", "health", "medical"]
+
+    if any(k in text for k in politics_kw):
+        return "Politics"
+    if any(k in text for k in tech_kw):
+        return "Tech/Visual"
+    return "General"
+
+
+@dataclass
+class Reference:
+    title: str
+    link: str
+
+
+@dataclass
+class Perspective:
+    viewpoint: str
+    detail: str
+
+
+@dataclass
+class Story:
+    """Structured representation of a news story."""
+
+    title: str
+    summary: str
+    link: str
+    source: str
+    category: str
+    relevance_score: float
+    bias_score: float
+    trending_score: float
+    perspectives: List[Perspective]
+    references: List[Reference]
+
+
+def fetch_top_stories(limit: int = 10) -> List[Story]:
+    """Fetch top stories from Google News RSS feed.
+
+    Args:
+        limit: Number of stories to return (1-100).
+
+    Returns:
+        List of Story objects limited by ``limit``.
+    """
+
+    feed_url = "https://news.google.com/rss?hl=en-IN&gl=IN&ceid=IN:en"
+    data = feedparser.parse(feed_url)
+    limit = max(1, min(limit, 100))
+    entries = data.entries[:limit]
+    stories: List[Story] = []
+
+    for idx, entry in enumerate(entries):
+        raw_title = entry.get("title", "")
+        title, source = _split_title_source(raw_title)
+        link = _resolve_link(entry.get("link", ""))
+        summary = _clean_summary(entry.get("summary", ""))
+        published = entry.get("published_parsed")
+
+        if published:
+            published_dt = datetime(*published[:6], tzinfo=timezone.utc)
+            hours_old = (datetime.now(timezone.utc) - published_dt).total_seconds() / 3600
+            trending_score = max(0.0, 1 - hours_old / 24)
+        else:
+            trending_score = 0.5
+
+        relevance_score = 1.0 if "India" in title else 0.5
+        bias_score = 0.5  # Placeholder until real bias detection is implemented
+        category = _categorize(title, summary)
+
+        perspectives = [
+            Perspective("left", f"Left perspective on {title}"),
+            Perspective("center", f"Centrist view on {title}"),
+            Perspective("right", f"Right perspective on {title}"),
+        ]
+
+        ref_entries = data.entries[idx + 1 : idx + 5]
+        references = []
+        for e in ref_entries:
+            r_title, _ = _split_title_source(e.get("title", ""))
+            r_link = _resolve_link(e.get("link", ""))
+            references.append(Reference(r_title, r_link))
+        while len(references) < 4:
+            references.append(Reference(title, link))
+
+        stories.append(
+            Story(
+                title=title,
+                summary=summary,
+                link=link,
+                source=source,
+                category=category,
+                relevance_score=relevance_score,
+                bias_score=bias_score,
+                trending_score=trending_score,
+                perspectives=perspectives,
+                references=references,
+            )
+        )
+
+    return stories

--- a/newsfeed/models.py
+++ b/newsfeed/models.py
@@ -16,6 +16,14 @@ class Reference:
 
 
 @dataclass
+class Perspective:
+    """A viewpoint-specific note for a story."""
+
+    label: str
+    text: str
+
+
+@dataclass
 class Score:
     """Numeric score with an optional explanation."""
 
@@ -48,6 +56,7 @@ class Story:
     bias: Score
     trending: Score
     references: List[Reference]
+    perspectives: List[Perspective]
 
     @property
     def relevance_score(self) -> float:  # backward compatibility

--- a/newsfeed/models.py
+++ b/newsfeed/models.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+"""Core data models used across the newsfeed package."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List
+
+
+@dataclass
+class Reference:
+    """A supporting reference link for a story."""
+
+    title: str
+    link: str
+
+
+@dataclass
+class Perspective:
+    """Represents a single viewpoint on a story."""
+
+    viewpoint: str
+    detail: str
+
+
+@dataclass
+class Score:
+    """Numeric score with an optional explanation."""
+
+    value: float
+    explanation: str = ""
+
+
+@dataclass
+class Article:
+    """Raw article information produced by a crawler."""
+
+    title: str
+    summary: str
+    link: str
+    source: str
+    published: datetime
+
+
+@dataclass
+class Story:
+    """Fully analysed story presented to editors."""
+
+    title: str
+    summary: str
+    link: str
+    source: str
+    category: str
+    published: datetime
+    relevance: Score
+    bias: Score
+    trending: Score
+    perspectives: List[Perspective]
+    references: List[Reference]
+
+    @property
+    def relevance_score(self) -> float:  # backward compatibility
+        return self.relevance.value
+
+    @property
+    def bias_score(self) -> float:
+        return self.bias.value
+
+    @property
+    def trending_score(self) -> float:
+        return self.trending.value

--- a/newsfeed/models.py
+++ b/newsfeed/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Core data models used across the newsfeed package."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import List
 
@@ -57,6 +57,7 @@ class Story:
     trending: Score
     references: List[Reference]
     perspectives: List[Perspective]
+    stats: List[str] = field(default_factory=list)
 
     @property
     def relevance_score(self) -> float:  # backward compatibility

--- a/newsfeed/models.py
+++ b/newsfeed/models.py
@@ -16,14 +16,6 @@ class Reference:
 
 
 @dataclass
-class Perspective:
-    """Represents a single viewpoint on a story."""
-
-    viewpoint: str
-    detail: str
-
-
-@dataclass
 class Score:
     """Numeric score with an optional explanation."""
 
@@ -55,7 +47,6 @@ class Story:
     relevance: Score
     bias: Score
     trending: Score
-    perspectives: List[Perspective]
     references: List[Reference]
 
     @property

--- a/newsfeed/story_builder.py
+++ b/newsfeed/story_builder.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import List
 
 from .models import Story, Reference
-from .crawler import GoogleNewsCrawler, related_links
+from .crawler import GoogleNewsCrawler, CuriousCrawler, related_links
 from .analytics import Analyzer
 
 
@@ -19,6 +19,8 @@ class StoryBuilder:
     def build(self, limit: int = 10, sort: str = "latest", include_twitter: bool = True) -> List[Story]:
         limit = max(1, min(limit, 100))
         articles = self.crawler.fetch(limit)
+        curious = CuriousCrawler().fetch(min(5, limit))
+        articles.extend(curious)
         stories: List[Story] = []
         seen_titles = set()
         for art in articles:
@@ -29,6 +31,7 @@ class StoryBuilder:
             category, relevance, bias, trending = self.analyzer.analyze(art)
             summary = self.analyzer.summarize(art)
             perspectives = self.analyzer.generate_perspectives(art)
+            stats = self.analyzer.extract_stats(art)
             references = related_links(art.title)
             stories.append(
                 Story(
@@ -43,6 +46,7 @@ class StoryBuilder:
                     trending=trending,
                     references=references,
                     perspectives=perspectives,
+                    stats=stats,
                 )
             )
 

--- a/newsfeed/story_builder.py
+++ b/newsfeed/story_builder.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+"""Assemble stories from crawled articles and analytics."""
+
+from datetime import datetime, timezone
+from typing import List
+
+from .models import Story, Perspective, Reference
+from .crawler import GoogleNewsCrawler, related_links
+from .analytics import Analyzer
+
+
+class StoryBuilder:
+    """High level orchestration for building ``Story`` objects."""
+
+    def __init__(self, crawler=None, analyzer=None) -> None:
+        self.crawler = crawler or GoogleNewsCrawler()
+        self.analyzer = analyzer or Analyzer()
+
+    def build(self, limit: int = 10, sort: str = "latest", include_twitter: bool = True) -> List[Story]:
+        limit = max(1, min(limit, 100))
+        google_limit = limit if not include_twitter else max(1, limit // 2)
+        articles = self.crawler.fetch(google_limit)
+        stories: List[Story] = []
+        for art in articles:
+            category, relevance, bias, trending = self.analyzer.analyze(art)
+            perspectives = [
+                Perspective("left", f"Left perspective on {art.title}"),
+                Perspective("center", f"Centrist view on {art.title}"),
+                Perspective("right", f"Right perspective on {art.title}"),
+            ]
+            references = related_links(art.title)
+            stories.append(
+                Story(
+                    title=art.title,
+                    summary=art.summary,
+                    link=art.link,
+                    source=art.source,
+                    category=category,
+                    published=art.published,
+                    relevance=relevance,
+                    bias=bias,
+                    trending=trending,
+                    perspectives=perspectives,
+                    references=references,
+                )
+            )
+
+        if include_twitter:
+            try:
+                from .twitter_feed import TwitterTrendsFetcher
+
+                t_fetcher = TwitterTrendsFetcher()
+                stories.extend(t_fetcher.fetch(limit - len(stories)))
+            except Exception:
+                pass
+
+        stories = self._sort(stories, sort)
+        return stories[:limit]
+
+    def _sort(self, stories: List[Story], sort: str) -> List[Story]:
+        sort = (sort or "latest").lower()
+        reverse = True
+        if sort == "trending":
+            key = lambda s: s.trending_score
+        elif sort == "top":
+            key = lambda s: s.relevance_score
+        elif sort == "oldest":
+            key = lambda s: s.published
+            reverse = False
+        else:  # latest
+            key = lambda s: s.published
+        return sorted(stories, key=key, reverse=reverse)

--- a/newsfeed/templates/index.html
+++ b/newsfeed/templates/index.html
@@ -4,9 +4,10 @@
     <meta charset="utf-8" />
     <title>News Brief</title>
     <style>
-        body { font-family: Arial, sans-serif; background:#f5f5f5; margin:0; padding:20px; }
-        .container { max-width:900px; margin:auto; }
+        body { font-family: Arial, sans-serif; background:#f0f2f5; margin:0; padding:20px; }
+        .container { max-width:1000px; margin:auto; }
         h1 { text-align:center; margin-bottom:30px; }
+        form.controls { display:flex; justify-content:space-between; background:#fff; padding:15px; border-radius:8px; box-shadow:0 1px 3px rgba(0,0,0,0.1); margin-bottom:20px; }
         .story { background:#fff; border-radius:8px; padding:20px; margin-bottom:20px; box-shadow:0 2px 4px rgba(0,0,0,0.1); }
         .story h2 { margin-top:0; }
         .meta { font-size:0.9em; color:#555; margin-bottom:10px; }
@@ -18,10 +19,22 @@
 <body>
 <div class="container">
     <h1>Top Stories</h1>
-    <form method="get" style="margin-bottom:20px;">
+    <form method="get" class="controls">
+        <div>
         <label>Stories per page:
             <input type="number" name="limit" min="1" max="100" value="{{ limit }}" />
         </label>
+        </div>
+        <div>
+        <label>Sort by:
+            <select name="sort">
+                <option value="latest" {% if sort=='latest' %}selected{% endif %}>Latest</option>
+                <option value="trending" {% if sort=='trending' %}selected{% endif %}>Trending</option>
+                <option value="top" {% if sort=='top' %}selected{% endif %}>Top</option>
+                <option value="oldest" {% if sort=='oldest' %}selected{% endif %}>Oldest</option>
+            </select>
+        </label>
+        </div>
         <input type="hidden" name="page" value="1" />
         <button type="submit">Update</button>
     </form>
@@ -32,11 +45,11 @@
             {% if story.source %}Source: {{ story.source }} &mdash; {% endif %}Category: {{ story.category }}
         </div>
         {% if story.summary %}<p>{{ story.summary }}</p>{% endif %}
-        <div class="scores">
-            <span>Relevance: {{ '%.2f'|format(story.relevance_score) }}</span>
-            <span>Bias: {{ '%.2f'|format(story.bias_score) }}</span>
-            <span>Trending: {{ '%.2f'|format(story.trending_score) }}</span>
-        </div>
+          <div class="scores">
+              <span title="{{ story.relevance.explanation }}">Relevance: {{ '%.2f'|format(story.relevance_score) }}</span>
+              <span title="{{ story.bias.explanation }}">Bias: {{ '%.2f'|format(story.bias_score) }}</span>
+              <span title="{{ story.trending.explanation }}">Trending: {{ '%.2f'|format(story.trending_score) }}</span>
+          </div>
         <details>
             <summary>Perspectives</summary>
             <ul>
@@ -57,10 +70,10 @@
     {% endfor %}
     <div class="pagination" style="text-align:center;">
         {% if prev_page %}
-        <a href="?limit={{ limit }}&page={{ prev_page }}">Previous</a>
+        <a href="?limit={{ limit }}&page={{ prev_page }}&sort={{ sort }}">Previous</a>
         {% endif %}
         {% if next_page %}
-        <a href="?limit={{ limit }}&page={{ next_page }}" style="margin-left:20px;">Next</a>
+        <a href="?limit={{ limit }}&page={{ next_page }}&sort={{ sort }}" style="margin-left:20px;">Next</a>
         {% endif %}
     </div>
 </div>

--- a/newsfeed/templates/index.html
+++ b/newsfeed/templates/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>News Brief</title>
+    <style>
+        body { font-family: Arial, sans-serif; background:#f5f5f5; margin:0; padding:20px; }
+        .container { max-width:900px; margin:auto; }
+        h1 { text-align:center; margin-bottom:30px; }
+        .story { background:#fff; border-radius:8px; padding:20px; margin-bottom:20px; box-shadow:0 2px 4px rgba(0,0,0,0.1); }
+        .story h2 { margin-top:0; }
+        .meta { font-size:0.9em; color:#555; margin-bottom:10px; }
+        .scores span { margin-right:10px; }
+        details { margin-top:10px; }
+        ol { padding-left:20px; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Top Stories</h1>
+    {% for story in stories %}
+    <div class="story">
+        <h2><a href="{{ story.link }}" target="_blank">{{ story.title }}</a></h2>
+        <div class="meta">
+            {% if story.source %}Source: {{ story.source }} &mdash; {% endif %}Category: {{ story.category }}
+        </div>
+        {% if story.summary %}<p>{{ story.summary }}</p>{% endif %}
+        <div class="scores">
+            <span>Relevance: {{ '%.2f'|format(story.relevance_score) }}</span>
+            <span>Bias: {{ '%.2f'|format(story.bias_score) }}</span>
+            <span>Trending: {{ '%.2f'|format(story.trending_score) }}</span>
+        </div>
+        <details>
+            <summary>Perspectives</summary>
+            <ul>
+                {% for p in story.perspectives %}
+                <li><strong>{{ p.viewpoint }}:</strong> {{ p.detail }}</li>
+                {% endfor %}
+            </ul>
+        </details>
+        <div class="references">
+            <p>References:</p>
+            <ol>
+            {% for ref in story.references %}
+                <li><a href="{{ ref.link }}" target="_blank">{{ ref.title }}</a></li>
+            {% endfor %}
+            </ol>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+</body>
+</html>

--- a/newsfeed/templates/index.html
+++ b/newsfeed/templates/index.html
@@ -2,80 +2,69 @@
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title>News Brief</title>
+    <title>News Dashboard</title>
     <style>
-        body { font-family: Arial, sans-serif; background:#f0f2f5; margin:0; padding:20px; }
-        .container { max-width:1000px; margin:auto; }
-        h1 { text-align:center; margin-bottom:30px; }
-        form.controls { display:flex; justify-content:space-between; background:#fff; padding:15px; border-radius:8px; box-shadow:0 1px 3px rgba(0,0,0,0.1); margin-bottom:20px; }
-        .story { background:#fff; border-radius:8px; padding:20px; margin-bottom:20px; box-shadow:0 2px 4px rgba(0,0,0,0.1); }
-        .story h2 { margin-top:0; }
-        .meta { font-size:0.9em; color:#555; margin-bottom:10px; }
-        .scores span { margin-right:10px; }
-        details { margin-top:10px; }
-        ol { padding-left:20px; }
+        body { font-family: Arial, sans-serif; background:#eef1f5; margin:0; }
+        header { background:#343a40; color:#fff; padding:10px 20px; }
+        header h1 { margin:0; }
+        .controls { margin-top:10px; display:flex; gap:10px; align-items:center; }
+        .controls input, .controls select { padding:4px; }
+        #stories { display:grid; grid-template-columns:repeat(auto-fill,minmax(300px,1fr)); gap:15px; padding:20px; }
+        .card { background:#fff; border-radius:8px; padding:15px; box-shadow:0 1px 3px rgba(0,0,0,0.1); }
+        .card h3 { margin-top:0; }
+        .meta { font-size:0.85em; color:#555; margin-bottom:8px; }
+        .scores span { margin-right:8px; font-size:0.85em; }
+        .refs { padding-left:16px; font-size:0.85em; }
+        #loadMore { display:block; margin:20px auto; padding:10px 20px; }
     </style>
 </head>
 <body>
-<div class="container">
-    <h1>Top Stories</h1>
-    <form method="get" class="controls">
-        <div>
-        <label>Stories per page:
-            <input type="number" name="limit" min="1" max="100" value="{{ limit }}" />
-        </label>
-        </div>
-        <div>
-        <label>Sort by:
-            <select name="sort">
-                <option value="latest" {% if sort=='latest' %}selected{% endif %}>Latest</option>
-                <option value="trending" {% if sort=='trending' %}selected{% endif %}>Trending</option>
-                <option value="top" {% if sort=='top' %}selected{% endif %}>Top</option>
-                <option value="oldest" {% if sort=='oldest' %}selected{% endif %}>Oldest</option>
-            </select>
-        </label>
-        </div>
-        <input type="hidden" name="page" value="1" />
-        <button type="submit">Update</button>
-    </form>
-    {% for story in stories %}
-    <div class="story">
-        <h2><a href="{{ story.link }}" target="_blank">{{ story.title }}</a></h2>
-        <div class="meta">
-            {% if story.source %}Source: {{ story.source }} &mdash; {% endif %}Category: {{ story.category }}
-        </div>
-        {% if story.summary %}<p>{{ story.summary }}</p>{% endif %}
-          <div class="scores">
-              <span title="{{ story.relevance.explanation }}">Relevance: {{ '%.2f'|format(story.relevance_score) }}</span>
-              <span title="{{ story.bias.explanation }}">Bias: {{ '%.2f'|format(story.bias_score) }}</span>
-              <span title="{{ story.trending.explanation }}">Trending: {{ '%.2f'|format(story.trending_score) }}</span>
-          </div>
-        <details>
-            <summary>Perspectives</summary>
-            <ul>
-                {% for p in story.perspectives %}
-                <li><strong>{{ p.viewpoint }}:</strong> {{ p.detail }}</li>
-                {% endfor %}
-            </ul>
-        </details>
-        <div class="references">
-            <p>References:</p>
-            <ol>
-            {% for ref in story.references %}
-                <li><a href="{{ ref.link }}" target="_blank">{{ ref.title }}</a></li>
-            {% endfor %}
-            </ol>
-        </div>
+<header>
+    <h1>News Dashboard</h1>
+    <div class="controls">
+        <label>Stories: <input type="number" id="limit" min="20" max="100" value="20"></label>
+        <label>Sort: <select id="sort">
+            <option value="latest">Latest</option>
+            <option value="trending">Trending</option>
+            <option value="top">Top</option>
+            <option value="oldest">Oldest</option>
+        </select></label>
+        <button id="refresh">Refresh</button>
     </div>
-    {% endfor %}
-    <div class="pagination" style="text-align:center;">
-        {% if prev_page %}
-        <a href="?limit={{ limit }}&page={{ prev_page }}&sort={{ sort }}">Previous</a>
-        {% endif %}
-        {% if next_page %}
-        <a href="?limit={{ limit }}&page={{ next_page }}&sort={{ sort }}" style="margin-left:20px;">Next</a>
-        {% endif %}
-    </div>
-</div>
+</header>
+<div id="stories"></div>
+<button id="loadMore">Load More</button>
+<script>
+let offset = 0;
+async function loadStories(reset=false){
+    const limit = parseInt(document.getElementById('limit').value)||20;
+    const sort = document.getElementById('sort').value;
+    const res = await fetch(`/stories?limit=${limit}&sort=${sort}&offset=${reset?0:offset}`);
+    const data = await res.json();
+    if(reset){
+        document.getElementById('stories').innerHTML='';
+        offset = 0;
+    }
+    data.forEach(st => {
+        const card = document.createElement('div');
+        card.className = 'card';
+        card.innerHTML = `<h3><a href="${st.link}" target="_blank">${st.title}</a></h3>
+            <div class="meta">${st.source ? `Source: ${st.source} — ` : ''}Category: ${st.category}</div>
+            <p>${st.summary || ''}</p>
+            <div class="scores">
+                <span title="${st.relevance_expl}">Rel: ${st.relevance.toFixed(2)}</span>
+                <span title="${st.bias_expl}">Bias: ${st.bias.toFixed(2)}</span>
+                <span title="${st.trending_expl}">Trend: ${st.trending.toFixed(2)}</span>
+            </div>
+            <ul class="refs">${st.references.map(r=>`<li><a href="${r.link}" target="_blank">${r.title}</a></li>`).join('')}</ul>`;
+        document.getElementById('stories').appendChild(card);
+    });
+    offset += data.length;
+}
+
+document.getElementById('refresh').addEventListener('click', ()=>loadStories(true));
+document.getElementById('loadMore').addEventListener('click', ()=>loadStories());
+window.addEventListener('DOMContentLoaded', ()=>loadStories(true));
+</script>
 </body>
 </html>

--- a/newsfeed/templates/index.html
+++ b/newsfeed/templates/index.html
@@ -18,6 +18,13 @@
 <body>
 <div class="container">
     <h1>Top Stories</h1>
+    <form method="get" style="margin-bottom:20px;">
+        <label>Stories per page:
+            <input type="number" name="limit" min="1" max="100" value="{{ limit }}" />
+        </label>
+        <input type="hidden" name="page" value="1" />
+        <button type="submit">Update</button>
+    </form>
     {% for story in stories %}
     <div class="story">
         <h2><a href="{{ story.link }}" target="_blank">{{ story.title }}</a></h2>
@@ -48,6 +55,14 @@
         </div>
     </div>
     {% endfor %}
+    <div class="pagination" style="text-align:center;">
+        {% if prev_page %}
+        <a href="?limit={{ limit }}&page={{ prev_page }}">Previous</a>
+        {% endif %}
+        {% if next_page %}
+        <a href="?limit={{ limit }}&page={{ next_page }}" style="margin-left:20px;">Next</a>
+        {% endif %}
+    </div>
 </div>
 </body>
 </html>

--- a/newsfeed/templates/index.html
+++ b/newsfeed/templates/index.html
@@ -3,38 +3,52 @@
 <head>
     <meta charset="utf-8" />
     <title>News Dashboard</title>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <style>
-        body { font-family: Arial, sans-serif; background:#eef1f5; margin:0; }
-        header { background:#343a40; color:#fff; padding:10px 20px; }
-        header h1 { margin:0; }
-        .controls { margin-top:10px; display:flex; gap:10px; align-items:center; }
-        .controls input, .controls select { padding:4px; }
-        #stories { display:grid; grid-template-columns:repeat(auto-fill,minmax(300px,1fr)); gap:15px; padding:20px; }
-        .card { background:#fff; border-radius:8px; padding:15px; box-shadow:0 1px 3px rgba(0,0,0,0.1); }
-        .card h3 { margin-top:0; }
-        .meta { font-size:0.85em; color:#555; margin-bottom:8px; }
+        body { background:#f5f5f5; }
+        .controls { margin-top:20px; }
         .scores span { margin-right:8px; font-size:0.85em; }
-        .refs { padding-left:16px; font-size:0.85em; }
-        #loadMore { display:block; margin:20px auto; padding:10px 20px; }
     </style>
 </head>
 <body>
-<header>
-    <h1>News Dashboard</h1>
-    <div class="controls">
-        <label>Stories: <input type="number" id="limit" min="20" max="100" value="20"></label>
-        <label>Sort: <select id="sort">
-            <option value="latest">Latest</option>
-            <option value="trending">Trending</option>
-            <option value="top">Top</option>
-            <option value="oldest">Oldest</option>
-        </select></label>
-        <button id="refresh">Refresh</button>
+<nav class="blue darken-2">
+  <div class="nav-wrapper container">
+    <a href="#" class="brand-logo">News Dashboard</a>
+  </div>
+</nav>
+<div class="container">
+  <div class="row controls">
+    <div class="input-field col s3">
+      <input id="limit" type="number" min="20" max="100" value="20">
+      <label for="limit">Stories</label>
     </div>
-</header>
-<div id="stories"></div>
-<button id="loadMore">Load More</button>
+    <div class="input-field col s3">
+      <select id="sort">
+        <option value="latest" selected>Latest</option>
+        <option value="trending">Trending</option>
+        <option value="top">Top</option>
+        <option value="oldest">Oldest</option>
+      </select>
+      <label>Sort</label>
+    </div>
+    <div class="input-field col s3">
+      <a id="refresh" class="btn">Refresh</a>
+    </div>
+  </div>
+  <div id="stories" class="row"></div>
+  <div class="row center">
+    <a id="loadMore" class="btn grey lighten-1 black-text">Load More</a>
+  </div>
+</div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 <script>
+document.addEventListener('DOMContentLoaded', function() {
+    var elems = document.querySelectorAll('select');
+    M.FormSelect.init(elems);
+    loadStories(true);
+});
+
 let offset = 0;
 async function loadStories(reset=false){
     const limit = parseInt(document.getElementById('limit').value)||20;
@@ -46,25 +60,42 @@ async function loadStories(reset=false){
         offset = 0;
     }
     data.forEach(st => {
+        const col = document.createElement('div');
+        col.className = 'col s12 m6';
         const card = document.createElement('div');
         card.className = 'card';
-        card.innerHTML = `<h3><a href="${st.link}" target="_blank">${st.title}</a></h3>
-            <div class="meta">${st.source ? `Source: ${st.source} — ` : ''}Category: ${st.category}</div>
-            <p>${st.summary || ''}</p>
-            <div class="scores">
-                <span title="${st.relevance_expl}">Rel: ${st.relevance.toFixed(2)}</span>
-                <span title="${st.bias_expl}">Bias: ${st.bias.toFixed(2)}</span>
-                <span title="${st.trending_expl}">Trend: ${st.trending.toFixed(2)}</span>
-            </div>
-            <ul class="refs">${st.references.map(r=>`<li><a href="${r.link}" target="_blank">${r.title}</a></li>`).join('')}</ul>`;
-        document.getElementById('stories').appendChild(card);
+        card.innerHTML = `
+        <div class="card-content">
+          <span class="card-title"><a href="${st.link}" target="_blank">${st.title}</a></span>
+          <p class="grey-text text-darken-1">${st.source ? `Source: ${st.source} — ` : ''}Category: ${st.category}</p>
+          <p>${st.summary || ''}</p>
+          <p class="scores">
+            <span title="${st.relevance_expl}">Rel: ${st.relevance.toFixed(2)}</span>
+            <span title="${st.bias_expl}">Bias: ${st.bias.toFixed(2)}</span>
+            <span title="${st.trending_expl}">Trend: ${st.trending.toFixed(2)}</span>
+          </p>
+        </div>
+        <div class="card-action">
+          <ul class="collapsible">
+            <li>
+              <div class="collapsible-header">Perspectives</div>
+              <div class="collapsible-body"><ul>${st.perspectives.map(p=>`<li><strong>${p.label}:</strong> ${p.text}</li>`).join('')}</ul></div>
+            </li>
+            <li>
+              <div class="collapsible-header">References</div>
+              <div class="collapsible-body"><ul>${st.references.map(r=>`<li><a href="${r.link}" target="_blank">${r.title}</a></li>`).join('')}</ul></div>
+            </li>
+          </ul>
+        </div>`;
+        col.appendChild(card);
+        document.getElementById('stories').appendChild(col);
+        M.Collapsible.init(card.querySelectorAll('.collapsible'));
     });
     offset += data.length;
 }
 
 document.getElementById('refresh').addEventListener('click', ()=>loadStories(true));
 document.getElementById('loadMore').addEventListener('click', ()=>loadStories());
-window.addEventListener('DOMContentLoaded', ()=>loadStories(true));
 </script>
 </body>
 </html>

--- a/newsfeed/templates/index.html
+++ b/newsfeed/templates/index.html
@@ -78,6 +78,10 @@ async function loadStories(reset=false){
         <div class="card-action">
           <ul class="collapsible">
             <li>
+              <div class="collapsible-header">Data Points</div>
+              <div class="collapsible-body"><ul>${st.stats.map(s=>`<li>${s}</li>`).join('')}</ul></div>
+            </li>
+            <li>
               <div class="collapsible-header">Perspectives</div>
               <div class="collapsible-body"><ul>${st.perspectives.map(p=>`<li><strong>${p.label}:</strong> ${p.text}</li>`).join('')}</ul></div>
             </li>

--- a/newsfeed/twitter_feed.py
+++ b/newsfeed/twitter_feed.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Fetch trending tweets from high-impact accounts."""
 
+from datetime import datetime, timezone
 from typing import List
 import os
 
@@ -10,7 +11,8 @@ try:
 except Exception:  # pragma: no cover - tweepy optional
     tweepy = None
 
-from .fetcher import Story, Perspective, Reference, _categorize
+from .models import Story, Perspective, Reference, Score
+from .analytics import categorize
 
 
 class TwitterTrendsFetcher:
@@ -61,7 +63,7 @@ class TwitterTrendsFetcher:
         for username, tweet in tweets[:limit]:
             title = tweet.text
             link = f"https://twitter.com/{username}/status/{tweet.id}"
-            category = _categorize(title, "")
+            category = categorize(title, "")
             perspectives = [Perspective("tweet", title)]
             references = [Reference(title, link) for _ in range(4)]
             stories.append(
@@ -71,9 +73,10 @@ class TwitterTrendsFetcher:
                     link=link,
                     source=username,
                     category=category,
-                    relevance_score=0.5,
-                    bias_score=0.5,
-                    trending_score=1.0,
+                    published=datetime.now(timezone.utc),
+                    relevance=Score(0.5, "Derived from Twitter feed"),
+                    bias=Score(0.5, "Bias scoring not available"),
+                    trending=Score(1.0, "Trending on Twitter"),
                     perspectives=perspectives,
                     references=references,
                 )

--- a/newsfeed/twitter_feed.py
+++ b/newsfeed/twitter_feed.py
@@ -10,7 +10,7 @@ from typing import List
 import requests
 
 from .analytics import categorize
-from .models import Reference, Score, Story
+from .models import Reference, Score, Story, Perspective
 
 
 class TwitterTrendsFetcher:
@@ -73,6 +73,7 @@ class TwitterTrendsFetcher:
                     link = trend.get("url") or f"https://twitter.com/search?q={title}"
                     category = categorize(title, "")
                     references = [Reference(title, link) for _ in range(4)]
+                    perspectives = [Perspective("General", f"Discussion around {title}")]
                     stories.append(
                         Story(
                             title=title,
@@ -85,6 +86,7 @@ class TwitterTrendsFetcher:
                             bias=Score(0.5, "Bias scoring not available"),
                             trending=Score(1.0, f"Trending tab: {tab}"),
                             references=references,
+                            perspectives=perspectives,
                         )
                     )
                     if len(stories) >= limit:

--- a/newsfeed/twitter_feed.py
+++ b/newsfeed/twitter_feed.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+"""Fetch trending tweets from high-impact accounts."""
+
+from typing import List
+import os
+
+try:
+    import tweepy  # type: ignore
+except Exception:  # pragma: no cover - tweepy optional
+    tweepy = None
+
+from .fetcher import Story, Perspective, Reference, _categorize
+
+
+class TwitterTrendsFetcher:
+    """Retrieve tweets from influential accounts as news stories."""
+
+    HIGH_IMPACT_ACCOUNTS = [
+        "PMOIndia",
+        "narendramodi",
+        "ndtv",
+        "timesofindia",
+    ]
+
+    def __init__(self, bearer_token: str | None = None) -> None:
+        self.bearer_token = bearer_token or os.getenv("TWITTER_BEARER_TOKEN")
+        self.client = None
+        if tweepy and self.bearer_token:
+            try:
+                self.client = tweepy.Client(bearer_token=self.bearer_token, wait_on_rate_limit=True)
+            except Exception:
+                self.client = None
+
+    def fetch(self, limit: int = 5) -> List[Story]:
+        """Fetch recent tweets as ``Story`` objects.
+
+        Returns an empty list if credentials are missing or the API call fails.
+        """
+
+        if not self.client:
+            return []
+
+        tweets = []
+        for username in self.HIGH_IMPACT_ACCOUNTS:
+            try:
+                user = self.client.get_user(username=username)
+                user_id = user.data.id if user and user.data else None
+                if not user_id:
+                    continue
+                resp = self.client.get_users_tweets(user_id, max_results=5)
+                if resp.data:
+                    for t in resp.data:
+                        tweets.append((username, t))
+            except Exception:
+                continue
+            if len(tweets) >= limit:
+                break
+
+        stories: List[Story] = []
+        for username, tweet in tweets[:limit]:
+            title = tweet.text
+            link = f"https://twitter.com/{username}/status/{tweet.id}"
+            category = _categorize(title, "")
+            perspectives = [Perspective("tweet", title)]
+            references = [Reference(title, link) for _ in range(4)]
+            stories.append(
+                Story(
+                    title=title,
+                    summary=title,
+                    link=link,
+                    source=username,
+                    category=category,
+                    relevance_score=0.5,
+                    bias_score=0.5,
+                    trending_score=1.0,
+                    perspectives=perspectives,
+                    references=references,
+                )
+            )
+        return stories

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 feedparser
 Flask
 requests
-tweepy

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,3 @@ feedparser
 Flask
 requests
 beautifulsoup4
-sumy
-nltk

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+feedparser
+Flask
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 feedparser
 Flask
 requests
+tweepy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 feedparser
 Flask
 requests
+beautifulsoup4
+sumy
+nltk

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -34,3 +34,18 @@ def test_twitter_fetcher_handles_missing_credentials(monkeypatch):
     monkeypatch.delenv("TWITTER_API_SECRET", raising=False)
     tf = TwitterTrendsFetcher()
     assert tf.fetch(5) == []
+
+
+def test_deduplicates_titles(monkeypatch):
+    entries = [
+        DummyEntry(title="Same", link="http://example.com/1", summary="S"),
+        DummyEntry(title="Same", link="http://example.com/2", summary="S"),
+    ]
+
+    def fake_parse(url):
+        return DummyFeed(entries)
+
+    monkeypatch.setattr("newsfeed.crawler.feedparser.parse", fake_parse)
+
+    stories = fetch_top_stories(limit=10, include_twitter=False)
+    assert len(stories) == 1

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -28,7 +28,9 @@ def test_limit_and_references(monkeypatch):
         assert 0 <= story.trending_score <= 1
 
 
-def test_twitter_fetcher_handles_missing_token(monkeypatch):
+def test_twitter_fetcher_handles_missing_credentials(monkeypatch):
     monkeypatch.delenv("TWITTER_BEARER_TOKEN", raising=False)
+    monkeypatch.delenv("TWITTER_API_KEY", raising=False)
+    monkeypatch.delenv("TWITTER_API_SECRET", raising=False)
     tf = TwitterTrendsFetcher()
     assert tf.fetch(5) == []

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,4 +1,5 @@
 from newsfeed.fetcher import fetch_top_stories
+from newsfeed.twitter_feed import TwitterTrendsFetcher
 
 
 class DummyEntry(dict):
@@ -18,10 +19,16 @@ def test_limit_and_references(monkeypatch):
 
     monkeypatch.setattr("newsfeed.fetcher.feedparser.parse", fake_parse)
 
-    stories = fetch_top_stories(limit=5)
+    stories = fetch_top_stories(limit=5, include_twitter=False)
     assert len(stories) == 5
     for story in stories:
         assert len(story.references) == 4
         assert 0 <= story.relevance_score <= 1
         assert 0 <= story.bias_score <= 1
         assert 0 <= story.trending_score <= 1
+
+
+def test_twitter_fetcher_handles_missing_token(monkeypatch):
+    monkeypatch.delenv("TWITTER_BEARER_TOKEN", raising=False)
+    tf = TwitterTrendsFetcher()
+    assert tf.fetch(5) == []

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -26,6 +26,7 @@ def test_limit_and_references(monkeypatch):
         assert 0 <= story.relevance_score <= 1
         assert 0 <= story.bias_score <= 1
         assert 0 <= story.trending_score <= 1
+        assert isinstance(story.stats, list)
 
 
 def test_twitter_fetcher_handles_missing_credentials(monkeypatch):

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -17,7 +17,7 @@ def test_limit_and_references(monkeypatch):
     def fake_parse(url):
         return DummyFeed(entries)
 
-    monkeypatch.setattr("newsfeed.fetcher.feedparser.parse", fake_parse)
+    monkeypatch.setattr("newsfeed.crawler.feedparser.parse", fake_parse)
 
     stories = fetch_top_stories(limit=5, include_twitter=False)
     assert len(stories) == 5

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,0 +1,27 @@
+from newsfeed.fetcher import fetch_top_stories
+
+
+class DummyEntry(dict):
+    pass
+
+
+class DummyFeed:
+    def __init__(self, entries):
+        self.entries = entries
+
+
+def test_limit_and_references(monkeypatch):
+    entries = [DummyEntry(title=f"T{i}", link=f"http://example.com/{i}", summary="S") for i in range(10)]
+
+    def fake_parse(url):
+        return DummyFeed(entries)
+
+    monkeypatch.setattr("newsfeed.fetcher.feedparser.parse", fake_parse)
+
+    stories = fetch_top_stories(limit=5)
+    assert len(stories) == 5
+    for story in stories:
+        assert len(story.references) == 4
+        assert 0 <= story.relevance_score <= 1
+        assert 0 <= story.bias_score <= 1
+        assert 0 <= story.trending_score <= 1

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "builds": [
+    { "src": "api/index.py", "use": "@vercel/python" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "api/index.py" }
+  ]
+}
+


### PR DESCRIPTION
## Summary
- sanitize Google News RSS summaries and split out story source
- redesign HTML template with card layout and clearer scores for editors
- include optional source headings in generated briefs and install requests

## Testing
- `python -m py_compile newsfeed/*.py tests/test_fetcher.py generate_brief.py api/index.py`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b422fb60cc8330a75482f2b9758ea4